### PR TITLE
Feature/interlok 3210 clustering add unique

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -19,6 +19,5 @@ path_classifiers:
     - ".dependabot"
     - ".github"
     - ".lgtm.yml"
-
-generated:
-  exclude: "**/*.java"
+  generated:
+    exclude: "**/*.java"

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -19,3 +19,6 @@ path_classifiers:
     - ".dependabot"
     - ".github"
     - ".lgtm.yml"
+  generated:
+    exclude: "**/*.java"
+    

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -19,6 +19,3 @@ path_classifiers:
     - ".dependabot"
     - ".github"
     - ".lgtm.yml"
-
-generated:
-  exclude: "**/*.java"

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -19,6 +19,6 @@ path_classifiers:
     - ".dependabot"
     - ".github"
     - ".lgtm.yml"
-  generated:
-    exclude: "**/*.java"
-    
+
+generated:
+  exclude: "**/*.java"

--- a/src/main/java/com/adaptris/mgmt/cluster/ClusterInstance.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/ClusterInstance.java
@@ -17,15 +17,30 @@ public class ClusterInstance {
   @Setter
   private String jmxAddress;
   
+  @Getter
+  @Setter
+  private String uniqueId;
+  
   public ClusterInstance() {
   }
   
-  public ClusterInstance(UUID uuid, String jmxAddress) {
+  public ClusterInstance(UUID uuid, String uniqueId, String jmxAddress) {
     this.setClusterUuid(uuid);
     this.setJmxAddress(jmxAddress);
+    this.setUniqueId(uniqueId);
   }
   
   public String toString() {
-    return "[UUID: " + this.getClusterUuid().toString() + ", JMXAddress: " + this.getJmxAddress() + "]";
+    StringBuffer buffer = new StringBuffer();
+    buffer.append("[");
+    buffer.append("UUID: ");
+    buffer.append(this.getClusterUuid().toString());
+    buffer.append(", UniqueId: ");
+    buffer.append(this.getUniqueId());
+    buffer.append(", JMXAddress: ");
+    buffer.append(this.getJmxAddress());
+    buffer.append("]");
+    
+    return buffer.toString();
   }
 }

--- a/src/main/java/com/adaptris/mgmt/cluster/ClusterManagerComponent.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/ClusterManagerComponent.java
@@ -6,6 +6,8 @@ import java.util.Properties;
 
 import javax.management.ObjectName;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.management.ManagementComponent;
 import com.adaptris.core.util.JmxHelper;
@@ -25,6 +27,8 @@ import lombok.extern.slf4j.Slf4j;
 public class ClusterManagerComponent implements ManagementComponent {
   
   private static final String CLUSTER_NAME_KEY = "clusterName";
+  
+  private static final String CLUSTER_DEBUG_KEY = "clusterDebug";
   
   private static final String CLUSTER_MANAGER_OBJECT_NAME = "com.adaptris:type=ClusterManager,id=ClusterManager";
   
@@ -61,6 +65,7 @@ public class ClusterManagerComponent implements ManagementComponent {
     if(this.getBroadcaster() == null) {
       this.setBroadcaster(new JGroupsBroadcaster());
       this.getBroadcaster().setJGroupsClusterName(this.getClusterName());
+      this.getBroadcaster().setDebug(new Boolean(StringUtils.defaultIfBlank(config.getProperty(CLUSTER_DEBUG_KEY), "false")));
     }
       
     if(this.getListener() == null) {
@@ -68,8 +73,10 @@ public class ClusterManagerComponent implements ManagementComponent {
       this.getListener().setJGroupsClusterName(this.getClusterName());
     }
       
-    if(this.getClusterManager() == null)
+    if(this.getClusterManager() == null) {
       this.setClusterManager(new ClusterManager());
+      this.getClusterManager().setDebug(new Boolean(StringUtils.defaultIfBlank(config.getProperty(CLUSTER_DEBUG_KEY), "false"))); 
+    }
   }
 
   @Override

--- a/src/main/java/com/adaptris/mgmt/cluster/jgroups/Broadcaster.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/jgroups/Broadcaster.java
@@ -10,5 +10,7 @@ public interface Broadcaster extends ComponentLifecycle {
    public void setSendDelaySeconds(int parseInt);
    
    public void setJGroupsClusterName(String clusterName);
+   
+   public void setDebug(boolean debug);
   
 }

--- a/src/main/java/com/adaptris/mgmt/cluster/jgroups/PacketHelper.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/jgroups/PacketHelper.java
@@ -7,9 +7,11 @@ import com.adaptris.mgmt.cluster.ClusterInstance;
 
 public class PacketHelper {
     
-  public static final int STANDARD_PACKET_SIZE = 152;
+  public static final int STANDARD_PACKET_SIZE = 280;
   
   private static final int MAX_JMX_LENGTH = 128;
+  
+  private static final int MAX_ADAPTER_ID_LENGTH = 128;
   
   private static final String UTF8_ENCODING = "UTF-8";
     
@@ -19,8 +21,11 @@ public class PacketHelper {
     
     long bigBits = byteBuffer.getLong();
     long littleBits = byteBuffer.getLong();
+    byte[] adapterId = new byte[MAX_ADAPTER_ID_LENGTH];
     byte[] hostArray = new byte[MAX_JMX_LENGTH];
+    byteBuffer.get(adapterId);
     byteBuffer.get(hostArray);
+    ping.setUniqueId(new String(adapterId, UTF8_ENCODING).trim());
     ping.setJmxAddress(new String(hostArray, UTF8_ENCODING).trim());
     ping.setClusterUuid(new UUID(bigBits, littleBits));
     
@@ -32,6 +37,7 @@ public class PacketHelper {
     
     byteBuffer.putLong(ping.getClusterUuid().getMostSignificantBits());
     byteBuffer.putLong(ping.getClusterUuid().getLeastSignificantBits());
+    byteBuffer.put(padStringByteArray(ping.getUniqueId(), MAX_ADAPTER_ID_LENGTH));
     byteBuffer.put(padStringByteArray(ping.getJmxAddress(), MAX_JMX_LENGTH));
     
     return byteBuffer.array();

--- a/src/main/java/com/adaptris/mgmt/cluster/mbean/ClusterManager.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/mbean/ClusterManager.java
@@ -22,6 +22,9 @@ public class ClusterManager implements ClusterManagerMBean, ClusterInstanceEvent
   @Getter
   @Setter
   private ExpiringMapCache clusterInstances;
+  @Getter
+  @Setter
+  private boolean debug;
   
   // use a PAssiveExpiryMap
   public ClusterManager() throws CoreException {
@@ -61,19 +64,22 @@ public class ClusterManager implements ClusterManagerMBean, ClusterInstanceEvent
     synchronized(this.getClusterInstances()) {
       if(this.getClusterInstances().get(clusterInstance.getClusterUuid().toString()) == null) {
         this.getClusterInstances().put(clusterInstance.getClusterUuid().toString(), clusterInstance);
-        log.debug("Found new Cluster Instance: {}", clusterInstance);
+        if(this.isDebug())
+          log.debug("Found new Cluster Instance: {}", clusterInstance);
       } else {
         // refresh the instance on the cache, so it does not expire
         this.getClusterInstances().remove(clusterInstance.getClusterUuid().toString());
         this.getClusterInstances().put(clusterInstance.getClusterUuid().toString(), clusterInstance);
-        log.trace("Refreshed Cluster Instance {}", clusterInstance);
+        if(this.isDebug())
+          log.trace("Refreshed Cluster Instance {}", clusterInstance);
       }
     }
   }
 
   @Override
   public void clusterInstancePinged(ClusterInstance clusterInstance) {
-    log.trace("Cluster instance pinged: {}", clusterInstance);
+    if(this.isDebug())
+      log.trace("Cluster instance pinged: {}", clusterInstance);
     try {
       this.addClusterInstance(clusterInstance);
     } catch (CoreException ex) {

--- a/src/main/java/com/adaptris/mgmt/cluster/mbean/ClusterManager.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/mbean/ClusterManager.java
@@ -39,7 +39,7 @@ public class ClusterManager implements ClusterManagerMBean, ClusterInstanceEvent
   }
   
   @Override
-  public String getKnownClusterInstances() {
+  public String getKnownClusterInstancesAsString() {
     try {
       synchronized(this.getClusterInstances()) {
         return this.getClusterInstances().getKeys()

--- a/src/main/java/com/adaptris/mgmt/cluster/mbean/ClusterManagerMBean.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/mbean/ClusterManagerMBean.java
@@ -1,7 +1,11 @@
 package com.adaptris.mgmt.cluster.mbean;
 
+import com.adaptris.core.cache.ExpiringMapCache;
+
 public interface ClusterManagerMBean {
 
-  public String getKnownClusterInstances();
+  public String getKnownClusterInstancesAsString();
+  
+  public ExpiringMapCache getClusterInstances();
   
 }

--- a/src/test/java/com/adaptris/mgmt/cluster/ClusterInstanceTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/ClusterInstanceTest.java
@@ -12,6 +12,8 @@ public class ClusterInstanceTest {
   
   private static final UUID UNIQUE_ID = UUID.randomUUID();
 
+  private static final String ADAPTER_ID = "MyAdapterId";
+  
   private static final String JMX_ADDRESS = "JMX_ADDRESS";
   
   private ClusterInstance clusterInstance;
@@ -27,26 +29,27 @@ public class ClusterInstanceTest {
   
   @Test
   public void testSetAllConstructor() throws Exception {
-    clusterInstance = new ClusterInstance(UNIQUE_ID, JMX_ADDRESS);
+    clusterInstance = new ClusterInstance(UNIQUE_ID, ADAPTER_ID, JMX_ADDRESS);
     
     assertEquals(UNIQUE_ID, clusterInstance.getClusterUuid());
+    assertEquals(ADAPTER_ID, clusterInstance.getUniqueId());
     assertEquals(JMX_ADDRESS, clusterInstance.getJmxAddress());
   }
   
   @Test
   public void testEquals() throws Exception {
-    clusterInstance = new ClusterInstance(UNIQUE_ID, JMX_ADDRESS);
+    clusterInstance = new ClusterInstance(UNIQUE_ID, ADAPTER_ID, JMX_ADDRESS);
     
-    ClusterInstance clusterInstance2 = new ClusterInstance(UNIQUE_ID, JMX_ADDRESS);
+    ClusterInstance clusterInstance2 = new ClusterInstance(UNIQUE_ID, ADAPTER_ID, JMX_ADDRESS);
     
     assertEquals(clusterInstance.toString(), clusterInstance2.toString());
   }
   
   @Test
   public void testNotEquals() throws Exception {
-    clusterInstance = new ClusterInstance(UNIQUE_ID, JMX_ADDRESS);
+    clusterInstance = new ClusterInstance(UNIQUE_ID, ADAPTER_ID, JMX_ADDRESS);
     
-    ClusterInstance clusterInstance2 = new ClusterInstance(UUID.randomUUID(), JMX_ADDRESS);
+    ClusterInstance clusterInstance2 = new ClusterInstance(UUID.randomUUID(), ADAPTER_ID, JMX_ADDRESS);
     
     assertNotEquals(clusterInstance.toString(), clusterInstance2.toString());
   }

--- a/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsBroadcasterTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsBroadcasterTest.java
@@ -5,9 +5,15 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 import org.jgroups.JChannel;
 import org.junit.jupiter.api.AfterAll;
@@ -24,15 +30,29 @@ import com.adaptris.core.management.jmx.JmxRemoteComponent;
 import com.adaptris.mgmt.cluster.ClusterInstance;
 
 public class JGroupsBroadcasterTest {
+  
+  private static final String ADAPTER_REGISTRY = "com.adaptris:type=Registry,id=AdapterRegistry";
+  
+  private static final String ADAPTER_REGISTRY_ADAPTERS = "Adapters";
+  
+  private static final String ADAPTER_UNIQUE_ID = "UniqueId";
+  
+  private static final String CONNECTOR_SERVER = "com.adaptris:type=JmxConnectorServer";
+  
+  private static final String CONNECTOR_SERVER_ADDRESS = "Address";
 
   private static final String CLUSTER_NAME = "myClusterName";
+  
   private static final String HOST = null;
+  
   private static final int HOST_PORT = 0;
   
   @Mock
   private NetworkPingSender mockNetworkPingSender;
   @Mock
   private JChannel mockJChannel;
+  @Mock 
+  private MBeanServer mockMBeanServer;
   
   private JGroupsBroadcaster broadcaster;
   private ClusterInstance mockClusterInstance;
@@ -64,10 +84,25 @@ public class JGroupsBroadcasterTest {
     broadcaster = new JGroupsBroadcaster();
     broadcaster.setNetworkPingSender(mockNetworkPingSender);
     broadcaster.setJGroupsClusterName(CLUSTER_NAME);
+    broadcaster.setMbeanServer(mockMBeanServer);
     
     mockClusterInstance = new ClusterInstance();
     mockClusterInstance.setClusterUuid(UUID.randomUUID());
+    mockClusterInstance.setUniqueId("MyUniqueId");
     mockClusterInstance.setJmxAddress("myJmxAddress");
+    
+    ObjectName mockAdapterObjectName = new ObjectName("com.adaptris:type=Adapter,id=MyInterlokInstance");
+    
+    Set<ObjectName> adapterObjectNameSet = new HashSet<>();
+    adapterObjectNameSet.add(mockAdapterObjectName);
+    
+    when(mockMBeanServer.getAttribute(new ObjectName(ADAPTER_REGISTRY), ADAPTER_REGISTRY_ADAPTERS))
+        .thenReturn(adapterObjectNameSet);
+    when(mockMBeanServer.getAttribute(mockAdapterObjectName, ADAPTER_UNIQUE_ID))
+        .thenReturn("MyInterlokInstance");
+    when(mockMBeanServer.getAttribute(new ObjectName(CONNECTOR_SERVER), CONNECTOR_SERVER_ADDRESS))
+        .thenReturn("service:jmx:jmxmp://localhost:5555");
+    
   }
   
   @AfterEach
@@ -87,6 +122,7 @@ public class JGroupsBroadcasterTest {
   
   @Test
   public void testSendGeneratedClusterInstancePing() throws Exception {
+    broadcaster.setDebug(true);
     broadcaster.start();
     
     Thread.sleep(11000); // first ping will be sent after 10 seconds

--- a/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsListenerTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsListenerTest.java
@@ -42,6 +42,7 @@ public class JGroupsListenerTest {
         
     clusterInstance = new ClusterInstance();
     clusterInstance.setClusterUuid(UUID.randomUUID());
+    clusterInstance.setUniqueId("MyUniqueId");
     clusterInstance.setJmxAddress("myJmxAddress");
     
   }

--- a/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsNetworkPingSenderTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsNetworkPingSenderTest.java
@@ -33,7 +33,7 @@ public class JGroupsNetworkPingSenderTest {
   
   @Test
   public void testNotConnected() throws Exception {
-    pingSender.sendData("someHost", 999, new ClusterInstance(UUID.randomUUID(), "myJmxAddress"));
+    pingSender.sendData("someHost", 999, new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress"));
     
     verify(mockJChannel, times(0)).send(any(Message.class));
   }
@@ -42,7 +42,7 @@ public class JGroupsNetworkPingSenderTest {
   public void testIsConnected() throws Exception {
     when(mockJChannel.isConnected())
         .thenReturn(true);
-    pingSender.sendData("someHost", 999, new ClusterInstance(UUID.randomUUID(), "myJmxAddress"));
+    pingSender.sendData("someHost", 999, new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress"));
     
     verify(mockJChannel, times(1)).send(any(Message.class));
   }

--- a/src/test/java/com/adaptris/mgmt/cluster/mbean/ClusterManagerTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/mbean/ClusterManagerTest.java
@@ -1,21 +1,41 @@
 package com.adaptris.mgmt.cluster.mbean;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
+import com.adaptris.core.CoreException;
+import com.adaptris.core.cache.ExpiringMapCache;
 import com.adaptris.mgmt.cluster.ClusterInstance;
 
 public class ClusterManagerTest {
   
   private ClusterManager clusterManager;
   
+  @Mock private ExpiringMapCache mockClusterInstances;
+  
+  private List<String> mockKeySet;
+  
   @BeforeEach
   public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
     clusterManager = new ClusterManager();
+    
+    mockKeySet = new ArrayList<>();
+    mockKeySet.add("key");
   }
   
   @Test
@@ -38,6 +58,25 @@ public class ClusterManagerTest {
   }
   
   @Test
+  public void testClusterManagerMultipleNewInstanceNotReAdded() throws Exception {
+    clusterManager.setDebug(true);
+    UUID randomUUID = UUID.randomUUID();
+    
+    ClusterInstance clusterInstance1 = new ClusterInstance(randomUUID, "MyAdapterId", "myJmxAddress");
+    ClusterInstance clusterInstance2 = new ClusterInstance(randomUUID, "MyAdapterId2", "myJmxAddress2");
+    
+    clusterManager.clusterInstancePinged(clusterInstance1);
+    clusterManager.clusterInstancePinged(clusterInstance2);
+    clusterManager.clusterInstancePinged(clusterInstance1);
+    clusterManager.clusterInstancePinged(clusterInstance2);
+    
+    System.out.println(clusterManager.getKnownClusterInstancesAsString());
+    
+    assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf("myJmxAddress") >= 0);
+    assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf("myJmxAddress2") >= 0);
+  }
+  
+  @Test
   public void testClusterManagerMultipleNewInstance() throws Exception {
     clusterManager.setDebug(true);
     clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress"));
@@ -48,6 +87,37 @@ public class ClusterManagerTest {
     assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf("myJmxAddress") >= 0);
     assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf(",") > 0);
     assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf("myJmxAddress2") >= 0);
+  }
+  
+  @Test
+  public void testClusterManagerNoMap() throws Exception {
+    doThrow(new CoreException("expected"))
+        .when(mockClusterInstances).getKeys();
+        
+    clusterManager.setClusterInstances(mockClusterInstances);
+    
+    try {
+      assertNull(clusterManager.getKnownClusterInstancesAsString());
+    } catch (Exception ex) {
+      fail("Should return null and fail silently");
+    }
+  }
+  
+  @Test
+  public void testClusterManagerKeyFails() throws Exception {
+    // Should be impossible, but expiring map cache apparently can throw an exception here...
+    when(mockClusterInstances.getKeys())
+        .thenReturn(mockKeySet);
+    doThrow(new CoreException("expected"))
+        .when(mockClusterInstances).get(anyString());
+    
+    clusterManager.setClusterInstances(mockClusterInstances);
+    
+    try {
+      assertEquals("", clusterManager.getKnownClusterInstancesAsString());
+    } catch (Exception ex) {
+      fail("Should return null and fail silently");
+    }
   }
 
 }

--- a/src/test/java/com/adaptris/mgmt/cluster/mbean/ClusterManagerTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/mbean/ClusterManagerTest.java
@@ -22,7 +22,7 @@ public class ClusterManagerTest {
   public void testClusterManagerNewInstance() throws Exception {
     clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress"));
     
-    assertTrue(clusterManager.getKnownClusterInstances().contains("myJmxAddress"));
+    assertTrue(clusterManager.getKnownClusterInstancesAsString().contains("myJmxAddress"));
   }
   
   @Test
@@ -31,10 +31,10 @@ public class ClusterManagerTest {
     clusterManager.clusterInstancePinged(new ClusterInstance(randomUUID, "MyAdapterId", "myJmxAddress"));
     clusterManager.clusterInstancePinged(new ClusterInstance(randomUUID, "MyAdapterId", "myJmxAddress"));
     
-    System.out.println(clusterManager.getKnownClusterInstances());
+    System.out.println(clusterManager.getKnownClusterInstancesAsString());
     
-    assertTrue(clusterManager.getKnownClusterInstances().indexOf("myJmxAddress") >= 0);
-    assertTrue(clusterManager.getKnownClusterInstances().indexOf(",") == -1);
+    assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf("myJmxAddress") >= 0);
+    assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf(",") == -1);
   }
   
   @Test
@@ -43,11 +43,11 @@ public class ClusterManagerTest {
     clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress"));
     clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress2"));
     
-    System.out.println(clusterManager.getKnownClusterInstances());
+    System.out.println(clusterManager.getKnownClusterInstancesAsString());
     
-    assertTrue(clusterManager.getKnownClusterInstances().indexOf("myJmxAddress") >= 0);
-    assertTrue(clusterManager.getKnownClusterInstances().indexOf(",") > 0);
-    assertTrue(clusterManager.getKnownClusterInstances().indexOf("myJmxAddress2") >= 0);
+    assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf("myJmxAddress") >= 0);
+    assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf(",") > 0);
+    assertTrue(clusterManager.getKnownClusterInstancesAsString().indexOf("myJmxAddress2") >= 0);
   }
 
 }

--- a/src/test/java/com/adaptris/mgmt/cluster/mbean/ClusterManagerTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/mbean/ClusterManagerTest.java
@@ -20,7 +20,7 @@ public class ClusterManagerTest {
   
   @Test
   public void testClusterManagerNewInstance() throws Exception {
-    clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "myJmxAddress"));
+    clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress"));
     
     assertTrue(clusterManager.getKnownClusterInstances().contains("myJmxAddress"));
   }
@@ -28,8 +28,8 @@ public class ClusterManagerTest {
   @Test
   public void testClusterManagerNewInstanceNotReAdded() throws Exception {
     UUID randomUUID = UUID.randomUUID();
-    clusterManager.clusterInstancePinged(new ClusterInstance(randomUUID, "myJmxAddress"));
-    clusterManager.clusterInstancePinged(new ClusterInstance(randomUUID, "myJmxAddress"));
+    clusterManager.clusterInstancePinged(new ClusterInstance(randomUUID, "MyAdapterId", "myJmxAddress"));
+    clusterManager.clusterInstancePinged(new ClusterInstance(randomUUID, "MyAdapterId", "myJmxAddress"));
     
     System.out.println(clusterManager.getKnownClusterInstances());
     
@@ -39,8 +39,9 @@ public class ClusterManagerTest {
   
   @Test
   public void testClusterManagerMultipleNewInstance() throws Exception {
-    clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "myJmxAddress"));
-    clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "myJmxAddress2"));
+    clusterManager.setDebug(true);
+    clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress"));
+    clusterManager.clusterInstancePinged(new ClusterInstance(UUID.randomUUID(), "MyAdapterId", "myJmxAddress2"));
     
     System.out.println(clusterManager.getKnownClusterInstances());
     


### PR DESCRIPTION
## Motivation

The previous version of the cluster manager had a single job which was to report on the known JMX addresses of all other Interlok instances in your cluster.  This was fine considering it was built for the UI to be able to 'auto-discover' additional instances.  But actually the JMX address on it's own doesn't mean anything to the end user.  What if instead we display all of the known instances in the cluster and then the user picks the ones they want auto-added into the UI manager.  Only way to distinguish between instances might be through the Adapter's unique id.

## Modification

ClusterInstance now has a unique-id field, which is the adapters unique-id.  It also covers multiple adapters (comma separated unique-ids), should you be running in a container.
Also added a switch for logging, this component can be quite logging intensive every time it receives a ping from another instance.

## Result

Far better identification of each Instance in the cluster.
Can be used for picking and choosing the instances you want managed by the UI, or custom scripts that call our WebService.

## Testing
If you start an instance of interlok with the "cluster" management component, and "clusterName=" in your bootstrap.properties, then you'll see logging every 5 seconds that an instance was found (it is ofc it's own instance), in the logging you'll see the adapter-id as well as the UUID and JMX address.

