### PR TITLE
INTERLOK-3291 clusterConfig is now a new bootstrap.property

### DIFF
--- a/src/main/java/com/adaptris/mgmt/cluster/ClusterManagerComponent.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/ClusterManagerComponent.java
@@ -30,6 +30,8 @@ public class ClusterManagerComponent implements ManagementComponent {
   
   private static final String CLUSTER_DEBUG_KEY = "clusterDebug";
   
+  private static final String CLUSTER_CONFIG_KEY = "clusterConfig";
+  
   private static final String CLUSTER_MANAGER_OBJECT_NAME = "com.adaptris:type=ClusterManager,id=ClusterManager";
   
   @Getter
@@ -66,11 +68,13 @@ public class ClusterManagerComponent implements ManagementComponent {
       this.setBroadcaster(new JGroupsBroadcaster());
       this.getBroadcaster().setJGroupsClusterName(this.getClusterName());
       this.getBroadcaster().setDebug(new Boolean(StringUtils.defaultIfBlank(config.getProperty(CLUSTER_DEBUG_KEY), "false")));
+      this.getBroadcaster().setJGroupsConfiguration(config.getProperty(CLUSTER_CONFIG_KEY));
     }
       
     if(this.getListener() == null) {
       this.setListener(new JGroupsListener());
       this.getListener().setJGroupsClusterName(this.getClusterName());
+      this.getListener().setJGroupsConfiguration(config.getProperty(CLUSTER_CONFIG_KEY));
     }
       
     if(this.getClusterManager() == null) {

--- a/src/main/java/com/adaptris/mgmt/cluster/jgroups/AbstractListener.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/jgroups/AbstractListener.java
@@ -14,7 +14,11 @@ public abstract class AbstractListener implements ComponentLifecycle{
   @Getter
   @Setter
   private String jGroupsClusterName;
-    
+  
+  @Getter
+  @Setter
+  private String jGroupsConfiguration;
+  
   @Getter
   private List<ClusterInstanceEventListener> listeners;
   
@@ -34,4 +38,5 @@ public abstract class AbstractListener implements ComponentLifecycle{
     for(ClusterInstanceEventListener listener : this.getListeners())
       listener.clusterInstancePinged(pingData);
   }
+  
 }

--- a/src/main/java/com/adaptris/mgmt/cluster/jgroups/Broadcaster.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/jgroups/Broadcaster.java
@@ -12,5 +12,7 @@ public interface Broadcaster extends ComponentLifecycle {
    public void setJGroupsClusterName(String clusterName);
    
    public void setDebug(boolean debug);
+   
+   public void setJGroupsConfiguration(String resource);
   
 }

--- a/src/main/java/com/adaptris/mgmt/cluster/jgroups/JGroupsBroadcaster.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/jgroups/JGroupsBroadcaster.java
@@ -57,6 +57,9 @@ public class JGroupsBroadcaster implements Broadcaster {
   @Getter
   @Setter
   private boolean debug;
+  @Getter
+  @Setter
+  private String jGroupsConfiguration;
 
   public JGroupsBroadcaster() {
     this.setSendDelaySeconds(DEFAULT_SEND_DELAY_SECONDS);
@@ -65,7 +68,7 @@ public class JGroupsBroadcaster implements Broadcaster {
   
   @Override
   public void start() throws CoreException {
-    JGroupsChannel jGroupsChannel = JGroupsChannel.getInstance();
+    JGroupsChannel jGroupsChannel = JGroupsChannel.getInstance(this.getJGroupsConfiguration());
     jGroupsChannel.setClusterName(this.getJGroupsClusterName());
     try {
       jGroupsChannel.start();

--- a/src/main/java/com/adaptris/mgmt/cluster/jgroups/JGroupsChannel.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/jgroups/JGroupsChannel.java
@@ -1,6 +1,7 @@
 package com.adaptris.mgmt.cluster.jgroups;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 import org.jgroups.JChannel;
 
@@ -26,13 +27,23 @@ public class JGroupsChannel {
   @Setter
   private String clusterName;
   
+  @Getter
+  @Setter
+  private String configResource;
+  
   private JGroupsChannel() {
     // Singleton.
   }
   
   public static JGroupsChannel getInstance() {
+    return getInstance(null);
+  }
+  
+  public static JGroupsChannel getInstance(String configResource) {
     if(INSTANCE == null) {
-      INSTANCE = new JGroupsChannel();
+        INSTANCE = new JGroupsChannel();
+        if(configResource != null)
+          INSTANCE.setConfigResource(configResource);
     }
     
     return INSTANCE;
@@ -69,7 +80,7 @@ public class JGroupsChannel {
    * </p>
    * <p>
    * When JGroups is initialised the configuration file is taken from the META-INF directory of 
-   * this jar file.
+   * this jar file, or a configured override..
    * </p>
    */
   public void setJGroupsChannel(JChannel jChannel) {
@@ -77,10 +88,13 @@ public class JGroupsChannel {
   }
 
   private InputStream loadJGroupsConfiguration() {
-    InputStream resourceAsStream = this.getClass().getClassLoader().getResourceAsStream(BUNDLED_JGROUPS_CONFIG_FILE_NAME);
-    if(resourceAsStream != null)
-      return resourceAsStream;
-    return null;
+    return Optional.ofNullable(this.getConfigResource())
+        .map(configResource -> this.loadJGroupsConfiguration(configResource))
+        .orElse(this.loadJGroupsConfiguration(BUNDLED_JGROUPS_CONFIG_FILE_NAME));
+  }
+  
+  private InputStream loadJGroupsConfiguration(String configName) {
+    return this.getClass().getClassLoader().getResourceAsStream(configName);
   }
   
   public void start() throws Exception {
@@ -99,4 +113,7 @@ public class JGroupsChannel {
     }
   }
 
+  static void clear() {
+    INSTANCE = null;
+  }
 }

--- a/src/main/java/com/adaptris/mgmt/cluster/jgroups/JGroupsChannel.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/jgroups/JGroupsChannel.java
@@ -94,6 +94,7 @@ public class JGroupsChannel {
   }
   
   private InputStream loadJGroupsConfiguration(String configName) {
+    log.debug("Loading JGroups configuartion file named '{}'", configName);
     return this.getClass().getClassLoader().getResourceAsStream(configName);
   }
   

--- a/src/main/java/com/adaptris/mgmt/cluster/jgroups/JGroupsListener.java
+++ b/src/main/java/com/adaptris/mgmt/cluster/jgroups/JGroupsListener.java
@@ -17,7 +17,7 @@ public class JGroupsListener extends AbstractListener implements Receiver {
 
   @Override
   public void start() throws CoreException {
-    JGroupsChannel jGroupsChannel = JGroupsChannel.getInstance();
+    JGroupsChannel jGroupsChannel = JGroupsChannel.getInstance(this.getJGroupsConfiguration());
     jGroupsChannel.setClusterName(this.getJGroupsClusterName());
     
     try {

--- a/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsBroadcasterTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsBroadcasterTest.java
@@ -85,6 +85,7 @@ public class JGroupsBroadcasterTest {
     broadcaster.setNetworkPingSender(mockNetworkPingSender);
     broadcaster.setJGroupsClusterName(CLUSTER_NAME);
     broadcaster.setMbeanServer(mockMBeanServer);
+    broadcaster.setJGroupsConfiguration("cluster-manager.xml");
     
     mockClusterInstance = new ClusterInstance();
     mockClusterInstance.setClusterUuid(UUID.randomUUID());

--- a/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsChannelTest.java
+++ b/src/test/java/com/adaptris/mgmt/cluster/jgroups/JGroupsChannelTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.jgroups.JChannel;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +12,11 @@ public class JGroupsChannelTest {
     
   @BeforeEach
   public void setUp() throws Exception {
-    JGroupsChannel.getInstance().setJGroupsChannel(null);
+  }
+  
+  @AfterEach
+  public void tearDown() throws Exception {
+    JGroupsChannel.clear();
   }
 
   @Test
@@ -22,6 +27,13 @@ public class JGroupsChannelTest {
   @Test
   public void testNoReloadOfConfiguration() throws Exception {
     JChannel jGroupsChannel = JGroupsChannel.getInstance().getJGroupsChannel();
+    
+    assertEquals(jGroupsChannel, JGroupsChannel.getInstance().getJGroupsChannel());
+  }
+  
+  @Test
+  public void testNoReloadOfOverrideConfiguration() throws Exception {
+    JChannel jGroupsChannel = JGroupsChannel.getInstance("cluster-manager.xml").getJGroupsChannel();
     
     assertEquals(jGroupsChannel, JGroupsChannel.getInstance().getJGroupsChannel());
   }


### PR DESCRIPTION
## Motivation

ClusterManager is shipped with a default JGroups configuration file in the jars META-INF directory that uses the default TCP port of 7878.  Anyone wanting to use this component may want to override the defaults and use multicast or simply change the port number.  We should give them the opportunity to do so.

## Modification

A new bootstrap property named "clusterConfig" has been added to the current "clusterName" and "clusterDebug" properties.
This new property is now passed through from the cluster manager component into the broadcaster and listener (the 2 classes that bootstrap JGroups).

## Result
The class named JGroupsChannel is responsible for loading configuration when bootstrapping JGroups.
Now the JGroupsChannel class will use the new "clusterConfig" property to load the override config resource, if it's specified or will fallback to the default if not specified.

## Testing

Add a "clusterConfig" property with the name of your JGroups configuration file; "my-jgroups-config.xml".  Then make sure that file exists on the classpath.

Simply start the management component;
managementComponents="jetty:jms:cluster"

You'll then see during start-up a debug statement;
"Loading JGroups configuartion file named 'my-jgroups-config.xml'"
