### PR TITLE
INTERLOK-3555 Update the pom url to point to the right doc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -272,11 +272,12 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Management component for reporting on cluster instances.")
-        asNode().appendNode("url", "http://interlok.adaptris.net/interlok-docs/advanced-clustering.html")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-cluster")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.9.0+")
         properties.appendNode("license", "false")
         properties.appendNode("tags", "cluster,management")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-cluster-manager")
       }
     }
   }


### PR DESCRIPTION
## Motivation

The documentation was broken since we changed the doc site

## Modification

- Fix the doc url
- Add a repo url

## Result

The pom has a correct doc url and a new repo url

## Testing

Check that the new url and repo url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.
